### PR TITLE
Add import helper to load ESM packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ bar = Bar.new
 bar.v4 => "b305f5c4-db9a-4504-b0c3-4e097a5ec8b9"
 ```
 
+`import` is also supported for loading ESM packages:
+
+```ruby
+class Bar < Nodo::Core
+  import :uuid
+
+  function :v4, <<~JS
+    () => {
+      return uuid.v4();
+    }
+  JS
+end
+
+bar = Bar.new
+bar.v4 => "b305f5c4-db9a-4504-b0c3-4e097a5ec8b9"
+```
+
 ### Aliasing requires
 
 If the library name cannot be used as name of the constant, the `const` name

--- a/lib/nodo/core.rb
+++ b/lib/nodo/core.rb
@@ -82,7 +82,7 @@ module Nodo
 
       def generate_class_code
         <<~JS
-          (() => {
+          (async () => {
             const __nodo_klass__ = { nodo: global.nodo };
             #{dependencies.map(&:to_js).join}
             #{constants.map(&:to_js).join}
@@ -109,7 +109,13 @@ module Nodo
       def require(*mods)
         deps = mods.last.is_a?(Hash) ? mods.pop : {}
         mods = mods.map { |m| [m, m] }.to_h
-        self.dependencies = dependencies + mods.merge(deps).map { |name, package| Dependency.new(name, package) }
+        self.dependencies = dependencies + mods.merge(deps).map { |name, package| Dependency.new(name, package, type: :cjs) }
+      end
+
+      def import(*mods)
+        deps = mods.last.is_a?(Hash) ? mods.pop : {}
+        mods = mods.map { |m| [m, m] }.to_h
+        self.dependencies = dependencies + mods.merge(deps).map { |name, package| Dependency.new(name, package, type: :esm) }
       end
 
       def function(name, _code = nil, timeout: Nodo.timeout, code: nil, &block)

--- a/lib/nodo/dependency.rb
+++ b/lib/nodo/dependency.rb
@@ -1,16 +1,39 @@
 module Nodo
   class Dependency
-    attr_reader :name, :package
-    
-    def initialize(name, package)
-      @name, @package = name, package
+    attr_reader :name, :package, :type
+
+    def initialize(name, package, type:)
+      @name, @package, @type = name, package, type
     end
-  
+
     def to_js
+      case type
+      when :cjs then to_cjs
+      when :esm then to_esm
+      else raise "Unknown dependency type: #{type}"
+      end
+    end
+
+    private
+
+    def to_cjs
       <<~JS
         const #{name} = __nodo_klass__.#{name} = (() => {
           try {
             return require(#{package.to_json});
+          } catch(e) {
+            e.nodo_dependency = #{package.to_json};
+            throw e;
+          }
+        })();
+      JS
+    end
+
+    def to_esm
+      <<~JS
+        const #{name} = __nodo_klass__.#{name} = await (async () => {
+          try {
+            return await nodo.import(#{package.to_json});
           } catch(e) {
             e.nodo_dependency = #{package.to_json};
             throw e;

--- a/lib/nodo/nodo.cjs
+++ b/lib/nodo/nodo.cjs
@@ -99,8 +99,12 @@ module.exports = (function() {
 
           try {
             if (DEFINE_METHOD == method) {
-              classes[class_name] = vm.runInThisContext(input, class_name);
-              respond_with_data(res, class_name, start);
+              Promise.resolve(vm.runInThisContext(input, class_name)).then((result) => {
+                classes[class_name] = result;
+                respond_with_data(res, class_name, start);
+              }).catch((error) => {
+                respond_with_error(res, 500, error);
+              })
             } else if (EVALUATE_METHOD == method) {
               Promise.resolve(vm.runInNewContext(input, context)).then((result) => {
                 respond_with_data(res, result, start);


### PR DESCRIPTION
Currently, to use an ESM package in multiple functions, I would have to import it in each function like this:

```ruby
class Bar < Nodo::Core
  function :v4, <<~JS
    async () => {
      const uuid = await nodo.import('uuid')
      return uuid.v4();
    }
  JS

  function :v1, <<~JS
    async () => {
      const uuid = await nodo.import('uuid')
      return uuid.v1();
    }
  JS
end
```

This change adds an `import` helper that is similar to the `require` helper, so I can load the package once and just reference it in each function:
```ruby
class Bar < Nodo::Core
  import :uuid

  function :v4, <<~JS
    () => {
      return uuid.v4();
    }
  JS

  function :v1, <<~JS
    () => {
      return uuid.v1();
    }
  JS
end
```