### PR TITLE
Add ability to pass flags to Node binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ If the executable is located in your `PATH`, no configuration is required. Other
 Nodo.binary = '/usr/local/bin/node'
 ```
 
+Set flags on the binary like so
+```ruby
+Nodo.binary_flags << '--enable-source-maps'
+```
+
 ## Usage
 
 In Nodo, you define JS functions as you would define Ruby methods:

--- a/lib/nodo.rb
+++ b/lib/nodo.rb
@@ -9,11 +9,12 @@ require 'forwardable'
 
 module Nodo
   class << self
-    attr_accessor :modules_root, :env, :binary, :logger, :debug, :timeout
+    attr_accessor :modules_root, :env, :binary, :binary_flags, :logger, :debug, :timeout
   end
   self.modules_root = './node_modules'
   self.env = {}
   self.binary = 'node'
+  self.binary_flags = []
   self.logger = Logger.new(STDOUT)
   self.debug  = false
   self.timeout = 60

--- a/lib/nodo/core.rb
+++ b/lib/nodo/core.rb
@@ -211,7 +211,7 @@ module Nodo
       @@tmpdir = Pathname.new(Dir.mktmpdir('nodo'))
       env = Nodo.env.merge('NODE_PATH' => Nodo.modules_root.to_s)
       env['NODO_DEBUG'] = '1' if Nodo.debug
-      @@node_pid = Process.spawn(env, Nodo.binary, '-e', self.class.generate_core_code, '--', socket_path.to_s, err: :out)
+      @@node_pid = Process.spawn(env, Nodo.binary, '-e', self.class.generate_core_code, *Nodo.binary_flags, '--', socket_path.to_s, err: :out)
       at_exit do
         @@exiting = true
         Process.kill(:SIGTERM, node_pid) rescue Errno::ECHILD


### PR DESCRIPTION
For my usecase, it's helpful to have the `--enable-source-maps` flag passed to Node, as it makes stack traces clearer.

I've added a generic option to add parameters to a `Nodo.binary_flags` array, which will be passed into the spawned Node process. I've found this useful for that usecase, and I imagine there are other usecases that could also benefit from this.