### PR TITLE
Resolve ESM entry points from `package.json` `exports` field

### DIFF
--- a/lib/nodo/nodo.cjs
+++ b/lib/nodo/nodo.cjs
@@ -50,7 +50,61 @@ module.exports = (function() {
   }
 
   async function import_module(specifier) {
-    return await import(specifier);
+    if (!specifier.startsWith('.') && !specifier.startsWith('/')) {
+      try {
+        const defaultResolved = require.resolve(specifier);
+        const packageJsonPath = findPackageJson(defaultResolved);
+
+        if (packageJsonPath) {
+          const packageDirectory = path.dirname(packageJsonPath);
+          const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+          let esmEntry = null;
+
+          if (pkg.exports) {
+            const mainExport = pkg.exports['.'] || pkg.exports;
+
+            if (typeof mainExport === 'object') {
+              esmEntry = mainExport.import || mainExport.module || mainExport.default;
+            } else if (typeof mainExport === 'string' && mainExport.endsWith('.js')) {
+              esmEntry = mainExport;
+            }
+          }
+
+          if (!esmEntry && pkg.module) {
+            esmEntry = pkg.module;
+          }
+
+          if (!esmEntry && pkg.type === 'module' && pkg.main) {
+            esmEntry = pkg.main;
+          }
+
+          if (esmEntry) {
+            return await import(path.resolve(packageDirectory, esmEntry));
+          }
+        }
+      } catch (e) {
+        debug(`ESM resolution failed for ${specifier}: ${e.message}`);
+      }
+    }
+
+    return await import(require.resolve(specifier));
+  }
+
+  function findPackageJson(startPath) {
+    let directory = path.dirname(startPath);
+
+    while (directory !== path.dirname(directory)) {
+      const packagePath = path.join(directory, 'package.json');
+
+      if (fs.existsSync(packagePath)) {
+        return packagePath;
+      }
+
+      directory = path.dirname(directory);
+    }
+
+    return null;
   }
 
   const core = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,33 @@
   "packages": {
     "": {
       "dependencies": {
+        "mock-cjs-only-package": "file:test/fixtures/mock-cjs-only-package",
+        "mock-dual-package": "file:test/fixtures/mock-dual-package",
+        "mock-esm-only-package": "file:test/fixtures/mock-esm-only-package",
+        "mock-legacy-dual-package": "file:test/fixtures/mock-legacy-dual-package",
+        "mock-legacy-esm-package": "file:test/fixtures/mock-legacy-esm-package",
         "uuid": "^8.3.2"
       }
+    },
+    "node_modules/mock-cjs-only-package": {
+      "resolved": "test/fixtures/mock-cjs-only-package",
+      "link": true
+    },
+    "node_modules/mock-dual-package": {
+      "resolved": "test/fixtures/mock-dual-package",
+      "link": true
+    },
+    "node_modules/mock-esm-only-package": {
+      "resolved": "test/fixtures/mock-esm-only-package",
+      "link": true
+    },
+    "node_modules/mock-legacy-dual-package": {
+      "resolved": "test/fixtures/mock-legacy-dual-package",
+      "link": true
+    },
+    "node_modules/mock-legacy-esm-package": {
+      "resolved": "test/fixtures/mock-legacy-esm-package",
+      "link": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -15,9 +40,39 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "test/fixtures/mock-cjs-only-package": {
+      "version": "1.0.0"
+    },
+    "test/fixtures/mock-dual-package": {
+      "version": "1.0.0"
+    },
+    "test/fixtures/mock-esm-only-package": {
+      "version": "1.0.0"
+    },
+    "test/fixtures/mock-legacy-dual-package": {
+      "version": "1.0.0"
+    },
+    "test/fixtures/mock-legacy-esm-package": {
+      "version": "1.0.0"
     }
   },
   "dependencies": {
+    "mock-cjs-only-package": {
+      "version": "file:test/fixtures/mock-cjs-only-package"
+    },
+    "mock-dual-package": {
+      "version": "file:test/fixtures/mock-dual-package"
+    },
+    "mock-esm-only-package": {
+      "version": "file:test/fixtures/mock-esm-only-package"
+    },
+    "mock-legacy-dual-package": {
+      "version": "file:test/fixtures/mock-legacy-dual-package"
+    },
+    "mock-legacy-esm-package": {
+      "version": "file:test/fixtures/mock-legacy-esm-package"
+    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "dependencies": {
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "mock-dual-package": "file:test/fixtures/mock-dual-package",
+    "mock-esm-only-package": "file:test/fixtures/mock-esm-only-package",
+    "mock-cjs-only-package": "file:test/fixtures/mock-cjs-only-package",
+    "mock-legacy-dual-package": "file:test/fixtures/mock-legacy-dual-package",
+    "mock-legacy-esm-package": "file:test/fixtures/mock-legacy-esm-package"
   }
 }

--- a/test/fixtures/mock-cjs-only-package/index.js
+++ b/test/fixtures/mock-cjs-only-package/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  entryType: 'cjs-only',
+  getValue: function() { return 'from-cjs-only'; }
+};

--- a/test/fixtures/mock-cjs-only-package/package.json
+++ b/test/fixtures/mock-cjs-only-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-cjs-only-package",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/test/fixtures/mock-dual-package/index.cjs
+++ b/test/fixtures/mock-dual-package/index.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  entryType: 'cjs',
+  getValue: function() { return 'from-cjs'; }
+};

--- a/test/fixtures/mock-dual-package/index.mjs
+++ b/test/fixtures/mock-dual-package/index.mjs
@@ -1,0 +1,2 @@
+export const entryType = 'esm';
+export function getValue() { return 'from-esm'; }

--- a/test/fixtures/mock-dual-package/package.json
+++ b/test/fixtures/mock-dual-package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mock-dual-package",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    }
+  }
+}

--- a/test/fixtures/mock-esm-only-package/index.js
+++ b/test/fixtures/mock-esm-only-package/index.js
@@ -1,0 +1,2 @@
+export const entryType = 'esm-only';
+export function getValue() { return 'from-esm-only'; }

--- a/test/fixtures/mock-esm-only-package/package.json
+++ b/test/fixtures/mock-esm-only-package/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mock-esm-only-package",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/test/fixtures/mock-legacy-dual-package/index.cjs
+++ b/test/fixtures/mock-legacy-dual-package/index.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  entryType: 'cjs',
+  getValue: function() { return 'from-legacy-cjs'; }
+};

--- a/test/fixtures/mock-legacy-dual-package/index.mjs
+++ b/test/fixtures/mock-legacy-dual-package/index.mjs
@@ -1,0 +1,2 @@
+export const entryType = 'esm';
+export function getValue() { return 'from-legacy-esm'; }

--- a/test/fixtures/mock-legacy-dual-package/package.json
+++ b/test/fixtures/mock-legacy-dual-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mock-legacy-dual-package",
+  "version": "1.0.0",
+  "main": "./index.cjs",
+  "module": "./index.mjs"
+}

--- a/test/fixtures/mock-legacy-esm-package/index.js
+++ b/test/fixtures/mock-legacy-esm-package/index.js
@@ -1,0 +1,2 @@
+export const entryType = 'esm';
+export function getValue() { return 'from-legacy-type-module'; }

--- a/test/fixtures/mock-legacy-esm-package/package.json
+++ b/test/fixtures/mock-legacy-esm-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mock-legacy-esm-package",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/test/nodo_test.rb
+++ b/test/nodo_test.rb
@@ -8,7 +8,7 @@ class NodoTest < Minitest::Test
     end
     assert_equal 'Hello Nodo!', nodo.new.say_hi('Nodo')
   end
-  
+
   def test_require
     nodo = Class.new(Nodo::Core) do
       require :fs
@@ -17,7 +17,7 @@ class NodoTest < Minitest::Test
     assert_equal true, nodo.instance.exists_file(__FILE__)
     assert_equal false, nodo.instance.exists_file('FOOBARFOO')
   end
-  
+
   def test_require_npm
     nodo = Class.new(Nodo::Core) do
       require :uuid
@@ -26,7 +26,7 @@ class NodoTest < Minitest::Test
     assert uuid = nodo.new.v4
     assert_equal 36, uuid.size
   end
-  
+
   def test_const
     nodo = Class.new(Nodo::Core) do
       const :FOOBAR, 123
@@ -34,7 +34,7 @@ class NodoTest < Minitest::Test
     end
     assert_equal 123, nodo.new.get_const
   end
-  
+
   def test_script
     nodo = Class.new(Nodo::Core) do
       script "var somevar = 99;"
@@ -42,7 +42,7 @@ class NodoTest < Minitest::Test
     end
     assert_equal 99, nodo.new.get_somevar
   end
-  
+
   def test_deferred_script_definition_by_block
     nodo = Class.new(Nodo::Core) do
       singleton_class.attr_accessor :value
@@ -54,7 +54,7 @@ class NodoTest < Minitest::Test
     nodo.value = 123
     assert_equal 123, nodo.new.get_somevar
   end
-  
+
   def test_cannot_define_both_code_and_block_for_script
     assert_raises ArgumentError do
       Class.new(Nodo::Core) do
@@ -64,14 +64,14 @@ class NodoTest < Minitest::Test
       end
     end
   end
-  
+
   def test_async_await
     nodo = Class.new(Nodo::Core) do
       function :do_something, "async () => { return await 'resolved'; }"
     end
     assert_equal 'resolved', nodo.new.do_something
   end
-  
+
   def test_inheritance
     klass = Class.new(Nodo::Core) do
       function :foo, "() => 'superclass'"
@@ -86,7 +86,7 @@ class NodoTest < Minitest::Test
     assert_equal 'callingsuperclass', subclass.new.bar
     assert_equal 'callingsubsubclass', subsubclass.new.bar
   end
-  
+
   def test_class_function
     nodo = Class.new(Nodo::Core) do
       function :hello, "() => 'world'"
@@ -94,7 +94,7 @@ class NodoTest < Minitest::Test
     end
     assert_equal 'world', nodo.hello
   end
-  
+
   def test_syntax
     nodo = Class.new(Nodo::Core) do
       function :test, timeout: nil, code: <<~'JS'
@@ -103,7 +103,7 @@ class NodoTest < Minitest::Test
     end
     assert_equal [1, 2, 3], nodo.new.test
   end
-  
+
   def test_deferred_function_definition_by_block
     nodo = lambda do
       Class.new(Nodo::Core) do
@@ -119,7 +119,7 @@ class NodoTest < Minitest::Test
     assert_equal [1, nil, 3], nodo.().new.test
     assert_equal [1, 222, 3], nodo.().tap { |klass| klass.value = 222 }.new.test
   end
-  
+
   def test_cannot_define_both_code_and_block_for_function
     assert_raises ArgumentError do
       Class.new(Nodo::Core) do
@@ -129,7 +129,7 @@ class NodoTest < Minitest::Test
       end
     end
   end
-  
+
   def test_code_is_required
     assert_raises ArgumentError do
       Class.new(Nodo::Core) do
@@ -138,7 +138,7 @@ class NodoTest < Minitest::Test
       end
     end
   end
-  
+
   def test_timeout
     nodo = Class.new(Nodo::Core) do
       function :sleep, timeout: 1, code: <<~'JS'
@@ -149,7 +149,7 @@ class NodoTest < Minitest::Test
       nodo.new.sleep(2)
     end
   end
-  
+
   def test_internal_method_names_are_reserved
     assert_raises ArgumentError do
       Class.new(Nodo::Core) do
@@ -157,7 +157,7 @@ class NodoTest < Minitest::Test
       end
     end
   end
-  
+
   def test_logging
     with_logger test_logger do
       assert_raises(Nodo::JavaScriptError) do
@@ -178,25 +178,25 @@ class NodoTest < Minitest::Test
       end
     end
   end
-  
+
   def test_evaluation
     assert_equal 8, Class.new(Nodo::Core).new.evaluate('3 + 5')
   end
-  
+
   def test_evaluation_can_access_constants
     nodo = Class.new(Nodo::Core) do
       const :FOO, 'bar'
     end
     assert_equal 'barfoo', nodo.new.evaluate('FOO + "foo"')
   end
-  
+
   def test_evaluation_can_access_functions
     nodo = Class.new(Nodo::Core) do
       function :hello, code: "(name) => `Hello ${name}!`"
     end
     assert_equal 'Hello World!', nodo.new.evaluate('hello("World")')
   end
-  
+
   def test_evaluation_contexts_properties_are_shared_between_instances
     nodo = Class.new(Nodo::Core) do
       const :LIST, []
@@ -209,7 +209,7 @@ class NodoTest < Minitest::Test
     assert_equal %w[one two], one.evaluate('list()')
     assert_equal %w[one two], two.evaluate('list()')
   end
-  
+
   def test_evaluation_contexts_locals_are_separated_by_instance
     nodo = Class.new(Nodo::Core)
     one = nodo.new
@@ -219,26 +219,26 @@ class NodoTest < Minitest::Test
     assert_equal %w[one], one.evaluate('list')
     assert_equal %w[two], two.evaluate('list')
   end
-  
+
   def test_evaluation_can_require_on_its_own
     nodo = Class.new(Nodo::Core).new
     nodo.evaluate('const uuid = require("uuid")')
     uuid = nodo.evaluate('uuid.v4()')
     assert_uuid uuid
   end
-  
+
   def test_evaluation_can_access_requires
     nodo = Class.new(Nodo::Core) { require :uuid }
     uuid = nodo.new.evaluate('uuid.v4()')
     assert_uuid uuid
   end
-  
+
   def test_cannot_instantiate_core
     assert_raises Nodo::ClassError do
       Nodo::Core.new
     end
   end
-  
+
   def test_dynamic_imports_in_functions
     klass = Class.new(Nodo::Core) do
       function :v4, <<~JS
@@ -254,7 +254,7 @@ class NodoTest < Minitest::Test
     assert_uuid uuid_2 = nodo.v4
     assert uuid_1 != uuid_2
   end
-  
+
   def test_dynamic_imports_in_evaluation
     nodo = Class.new(Nodo::Core)
     uuid = nodo.new.evaluate("nodo.import('uuid').then((uuid) => uuid.v4()).catch((e) => null)")
@@ -296,6 +296,31 @@ class NodoTest < Minitest::Test
     assert_uuid uuid
   end
 
+  def test_esm_resolution_uses_package_exports
+    nodo = Class.new(Nodo::Core) do
+      import :uuid
+      function :get_exports, "() => Object.keys(uuid)"
+    end
+
+    exports = nodo.new.get_exports
+    assert_includes exports, 'v4'
+    assert_includes exports, 'v1'
+  end
+
+  def test_esm_resolution_with_dynamic_import
+    nodo = Class.new(Nodo::Core) do
+      function :get_uuid_exports, <<~JS
+        async () => {
+          const mod = await nodo.import('uuid');
+          return Object.keys(mod);
+        }
+      JS
+    end
+
+    exports = nodo.new.get_uuid_exports
+    assert_includes exports, 'v4'
+  end
+
   private
 
   def test_logger
@@ -305,7 +330,7 @@ class NodoTest < Minitest::Test
       self
     end
   end
-  
+
   def with_logger(logger)
     prev_logger = Nodo.logger
     Nodo.logger = logger
@@ -313,7 +338,7 @@ class NodoTest < Minitest::Test
   ensure
     Nodo.logger = prev_logger
   end
-  
+
   def assert_uuid(obj)
     assert_match /\A\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\z/, obj
   end

--- a/test/nodo_test.rb
+++ b/test/nodo_test.rb
@@ -296,29 +296,62 @@ class NodoTest < Minitest::Test
     assert_uuid uuid
   end
 
-  def test_esm_resolution_uses_package_exports
+  def test_esm_resolution_prefers_esm_entry_point
     nodo = Class.new(Nodo::Core) do
-      import :uuid
-      function :get_exports, "() => Object.keys(uuid)"
-    end
-
-    exports = nodo.new.get_exports
-    assert_includes exports, 'v4'
-    assert_includes exports, 'v1'
-  end
-
-  def test_esm_resolution_with_dynamic_import
-    nodo = Class.new(Nodo::Core) do
-      function :get_uuid_exports, <<~JS
+      function :get_entry_type, <<~JS
         async () => {
-          const mod = await nodo.import('uuid');
-          return Object.keys(mod);
+          const mod = await nodo.import('mock-dual-package');
+          return mod.entryType;
         }
       JS
     end
 
-    exports = nodo.new.get_uuid_exports
-    assert_includes exports, 'v4'
+    assert_equal 'esm', nodo.new.get_entry_type
+  end
+
+  def test_esm_resolution_with_import_declaration
+    nodo = Class.new(Nodo::Core) do
+      import mockPkg: 'mock-dual-package'
+      function :get_entry_type, "() => mockPkg.entryType"
+    end
+
+    assert_equal 'esm', nodo.new.get_entry_type
+  end
+
+  def test_esm_resolution_esm_only_package
+    nodo = Class.new(Nodo::Core) do
+      import mockPkg: 'mock-esm-only-package'
+      function :get_entry_type, "() => mockPkg.entryType"
+    end
+
+    assert_equal 'esm-only', nodo.new.get_entry_type
+  end
+
+  def test_esm_resolution_cjs_only_package
+    nodo = Class.new(Nodo::Core) do
+      import mockPkg: 'mock-cjs-only-package'
+      function :get_entry_type, "() => mockPkg.default.entryType"
+    end
+
+    assert_equal 'cjs-only', nodo.new.get_entry_type
+  end
+
+  def test_esm_resolution_legacy_module_field
+    nodo = Class.new(Nodo::Core) do
+      import mockPkg: 'mock-legacy-dual-package'
+      function :get_entry_type, "() => mockPkg.entryType"
+    end
+
+    assert_equal 'esm', nodo.new.get_entry_type
+  end
+
+  def test_esm_resolution_legacy_type_module
+    nodo = Class.new(Nodo::Core) do
+      import mockPkg: 'mock-legacy-esm-package'
+      function :get_entry_type, "() => mockPkg.entryType"
+    end
+
+    assert_equal 'esm', nodo.new.get_entry_type
   end
 
   private


### PR DESCRIPTION
Thanks for this great gem, I'm a big fan of `nodo`! ❤️

I have been running into an issue with NPM packages that are ESM-only and define an `exports` map in their `package.json`. Nodo wasn't able to resolve the right file to `import` and failed with an error message like: 

```
Nodo::JavaScriptError: Cannot find package 'esm-only-package-name' imported from /Users/marcoroth/.local/share/mise/installs/ruby/3.3.8/lib/ruby/gems/3.3.0/gems/nodo-1.8.2/lib/nodo/nodo.cjs
```

This pull request updates the lookup, so when importing packages, it reads the `package.json` to find the ESM entry point.

Let me know if you need anything changed, thank you!